### PR TITLE
Allow `extend` and `keyField` on interfaceType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resideo/graphql-transform-federation",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "restricted"

--- a/src/transform-federation.ts
+++ b/src/transform-federation.ts
@@ -33,6 +33,11 @@ export interface FederationObjectConfig<TContext> {
   fields?: FederationFieldsConfig;
 }
 
+export interface FederationInterfaceConfig {
+  keyFields?: string[];
+  extend?: boolean;
+}
+
 export interface FederationConfig<TContext> {
   [objectName: string]: FederationObjectConfig<TContext>;
 }


### PR DESCRIPTION
## Motivation
![Screenshot from 2020-11-09 16-53-55](https://user-images.githubusercontent.com/5721314/98571194-3000a500-22ac-11eb-9f96-3919b2709908.png)
Our codebase is littered with this as we need to promoted type definitions that understand the extensibility of an `InterfaceType`.

Such types begin in this repository and are then repackaged on the GiraffeQL layer.

## Approach
I add a new type for Federated Interfaces and genericise the code to be less (sometimes misleadingly) object focused. 

![tenor (46)](https://user-images.githubusercontent.com/5721314/98571557-8c63c480-22ac-11eb-966d-5bd929f2e4ef.gif)
