### PR TITLE
Remove console log

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@resideo/graphql-transform-federation",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",
     "access": "restricted"

--- a/src/transform-sdl.ts
+++ b/src/transform-sdl.ts
@@ -112,7 +112,6 @@ export function addFederationAnnotations<TContext>(
           nodeTypeToDo.delete(currentNodeName);
 
           const { keyFields, extend } = federationConfig[currentNodeName];
-          console.log(keyFields, extend);
 
           const newDirectives = keyFields
             ? keyFields.map(keyField =>


### PR DESCRIPTION
# Motivation
A console log statement prints types at all layers of the stack. This causes unwanted noise.